### PR TITLE
Add optional shortcuts field to nested nodes in processed file

### DIFF
--- a/src/types.ts
+++ b/src/types.ts
@@ -2,9 +2,9 @@ import { Node, NodeType } from "figma-js";
 
 export type Shortcut = NodeType | "STYLE";
 
-export type Shortcuts = Record<Shortcut, TransformedNode[]>;
-
 export type TransformedNode = Node & { shortcuts?: Shortcuts };
+
+export type Shortcuts = Record<Shortcut, TransformedNode[]>;
 
 export type ProcessedFile = {
     fileId: string;

--- a/src/types.ts
+++ b/src/types.ts
@@ -2,6 +2,10 @@ import { Node, NodeType } from "figma-js";
 
 export type Shortcut = NodeType | "STYLE";
 
+export type Shortcuts = Record<Shortcut, TransformedNode[]>;
+
+export type TransformedNode = Node & { shortcuts?: Shortcuts };
+
 export type ProcessedFile = {
     fileId: string;
     name: string;
@@ -9,5 +13,5 @@ export type ProcessedFile = {
     thumbnailUrl: string;
     version: string;
     children: any;
-    shortcuts: Record<Shortcut, Node[]>;
+    shortcuts: Shortcuts;
 };


### PR DESCRIPTION
Objects in `shortcuts` can also have nested  `shortcuts` field. I added this information to types.