### PR TITLE
add object.fromentries polyfill

### DIFF
--- a/package.json
+++ b/package.json
@@ -36,8 +36,10 @@
     },
     "devDependencies": {
         "@types/jest": "^26.0.10",
+        "@types/object.fromentries": "^2.0.0",
         "figma-js": "^1.11.0",
         "husky": "^4.2.5",
+        "object.fromentries": "^2.0.2",
         "tsdx": "^0.13.2",
         "typescript": "^3.9.7"
     },

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -1,4 +1,5 @@
 import { Node } from "figma-js";
+import fromEntries from "object.fromentries";
 import { Shortcuts, ShortcutType } from "./types";
 
 export function uniqBy(arr: any[], key: string, set = new Set()) {
@@ -35,7 +36,7 @@ export const parseShortcutKeys = (obj: Record<string, any>): Shortcuts => {
         STYLE: "styles",
     };
 
-    return Object.fromEntries(
+    return fromEntries(
         Object.entries(obj).map(([k, v]) => [mapKeys[k as ShortcutType], v])
     ) as Shortcuts;
 };

--- a/yarn.lock
+++ b/yarn.lock
@@ -1132,6 +1132,11 @@
   resolved "https://registry.yarnpkg.com/@types/node/-/node-14.0.14.tgz#24a0b5959f16ac141aeb0c5b3cd7a15b7c64cbce"
   integrity sha512-syUgf67ZQpaJj01/tRTknkMNoBBLWJOBODF0Zm4NrXmiSuxjymFrxnTu1QVYRubhVkRcZLYZG8STTwJRdVm/WQ==
 
+"@types/object.fromentries@^2.0.0":
+  version "2.0.0"
+  resolved "https://registry.yarnpkg.com/@types/object.fromentries/-/object.fromentries-2.0.0.tgz#8349ec6c51011a729da61e0c86ed433609a9f9a6"
+  integrity sha512-y/4Jx68CzO0Uh+SIbINo1gk+k8H1WVphZTHjMOpLdV3p5NqajFCMNKjg78c7YyCedmeIHyRRFhfcMuVZcWRE6g==
+
 "@types/parse-json@^4.0.0":
   version "4.0.0"
   resolved "https://registry.yarnpkg.com/@types/parse-json/-/parse-json-4.0.0.tgz#2f8bb441434d163b35fb8ffdccd7138927ffb8c0"


### PR DESCRIPTION
Adds the [object.fromentries](https://www.npmjs.com/package/object.fromentries) package to polyfill `Object.fromEntries` in old versions of Node that don't support it.

closes #18 